### PR TITLE
feat: add navigation over Dockerfile-based projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # travelgrunt
 
-Travel **[Terragrunt](https://terragrunt.gruntwork.io/)** or **[Terraform](https://www.terraform.io/)** directory tree as a first class passenger! :airplane:
+Travel **[Terragrunt](https://terragrunt.gruntwork.io/)** or **[Terraform](https://www.terraform.io/)** or ... ANY directory tree as a first class passenger! :airplane:
 
 ## How to use?
 
@@ -31,6 +31,11 @@ mode: terraform
 mode: terraform_or_terragrunt
 ```
 :arrow_up: this will navigate through **both** Terraform and Terragrunt projects inside the repo.
+
+```
+mode: dockerfile
+```
+:arrow_up: with this `travelgrunt` will navigate across Dockerfiles or Dockerfile templates.
 
 ## Shell aliases
 

--- a/fixtures/config/include/dockerfile/Dockerfile
+++ b/fixtures/config/include/dockerfile/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+# this is a dummy fixture Dockerfile

--- a/fixtures/config/travelgrunt.yml.dockerfile
+++ b/fixtures/config/travelgrunt.yml.dockerfile
@@ -1,0 +1,1 @@
+mode: dockerfile

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,7 +37,7 @@ func NewConfig(path string) (cfg Config, err error) {
 }
 
 func validate(cfg Config) error {
-	allowedModes := []string{"terragrunt", "terraform", "terraform_or_terragrunt"}
+	allowedModes := []string{"terragrunt", "terraform", "terraform_or_terragrunt", "dockerfile"}
 
 	for _, mode := range allowedModes {
 		if cfg.Mode == mode {
@@ -62,6 +62,8 @@ func (cfg Config) IncludeFn() (fn func(os.DirEntry) bool) {
 		fn = include.IsTerraform
 	case "terraform_or_terragrunt":
 		fn = include.IsTerraformOrTerragrunt
+	case "dockerfile":
+		fn = include.IsDockerfile
 	default:
 		fn = nil
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,6 +31,7 @@ func TestNewConfig(t *testing.T) {
 		"travelgrunt.yml.terragrunt":              {cfg: getConfig("terragrunt", false), success: true, includeFn: include.IsTerragrunt},
 		"travelgrunt.yml.terraform":               {cfg: getConfig("terraform", false), success: true, includeFn: include.IsTerraform},
 		"travelgrunt.yml.terraform_or_terragrunt": {cfg: getConfig("terraform_or_terragrunt", false), success: true, includeFn: include.IsTerraformOrTerragrunt},
+		"travelgrunt.yml.dockerfile":              {cfg: getConfig("dockerfile", false), success: true, includeFn: include.IsDockerfile},
 		"travelgrunt.yml.invalid":                 {cfg: getConfig("", false), success: false, includeFn: nil},
 		"travelgrunt.yml.illegal":                 {cfg: getConfig("bogus", false), success: false, includeFn: nil},
 		"travelgrunt.yml.nonexistent":             {cfg: getConfig("terragrunt", true), success: true, includeFn: include.IsTerragrunt},

--- a/pkg/config/include/include.go
+++ b/pkg/config/include/include.go
@@ -23,3 +23,8 @@ func IsTerraform(d os.DirEntry) bool {
 func IsTerraformOrTerragrunt(d os.DirEntry) bool {
 	return IsTerraform(d) || IsTerragrunt(d)
 }
+
+// IsDockerfile tells us if we operate on Dockerfile(s) or Dockerfile template(s)
+func IsDockerfile(d os.DirEntry) bool {
+	return fileOrSymlink(d) && strings.Contains(strings.ToLower(d.Name()), "dockerfile")
+}

--- a/pkg/config/include/include_test.go
+++ b/pkg/config/include/include_test.go
@@ -20,12 +20,14 @@ func TestIncludeFn(t *testing.T) {
 		IsTerragrunt            bool
 		IsTerraform             bool
 		IsTerraformOrTerragrunt bool
+		IsDockerfile            bool
 	}
 
 	testCases := map[string]testCase{
-		"../../../fixtures/config/include/terragrunt/terragrunt.hcl": testCase{true, false, true},
-		"../../../fixtures/config/include/terraform/main.tf":         testCase{false, true, true},
-		"../../../fixtures/config/include/nothing/foo.bar":           testCase{false, false, false},
+		"../../../fixtures/config/include/terragrunt/terragrunt.hcl": testCase{true, false, true, false},
+		"../../../fixtures/config/include/terraform/main.tf":         testCase{false, true, true, false},
+		"../../../fixtures/config/include/dockerfile/Dockerfile":     testCase{false, false, false, true},
+		"../../../fixtures/config/include/nothing/foo.bar":           testCase{false, false, false, false},
 	}
 
 	err := filepath.WalkDir(fixturePath,
@@ -37,6 +39,7 @@ func TestIncludeFn(t *testing.T) {
 					assert.Equal(expected.IsTerragrunt, IsTerragrunt(d))
 					assert.Equal(expected.IsTerraform, IsTerraform(d))
 					assert.Equal(expected.IsTerraformOrTerragrunt, IsTerraformOrTerragrunt(d))
+					assert.Equal(expected.IsDockerfile, IsDockerfile(d))
 				}
 			}
 


### PR DESCRIPTION
This PR adds navigation over Dockerfile-based projects. As of release `0.3.X` and later we use custom function to filter relevant project paths from the all existing Git repository paths. We pass a custom function to `directory.Collect()` as a parameter :neckbeard: 

#### How to use?
Execute `echo "mode: dockerfile" > .travelgrunt.yml` in the root of a Dockerfile [mono]repo and then read [this](https://github.com/ivanilves/travelgrunt#how-to-use) chapter.

The purpose of this PR is to demonstrate - how [easy] is to add a new working mode to `travelgrunt` - will it be our Dockerfile, Golang source files, Makefile, files with some custom content/comments or any other beasts you spot in typical wild [mono]repo, where directory tree depth and number of subfolders is way to big to just `cd` productivelly. `#fatigue`

We can also think about "true" monorepos with very complex structures and implement more YAML-driven configs like:

```YAML
mode: advanced

rules:
  - path: terraform
    include:
      - terraform
      - terragrunt
  - path: code
    include:
      - golang
      - php
      - nodejs
   - path: build
     include: [Makefile]

```
Latter is for the future releases, of course, just thinking loudly here :innocent: 