### PR TITLE
chore: use environment variable to avoid duplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  GO_VERSION: 1.19
+
 on:
   push:
     branches: [ "main" ]
@@ -15,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Build
       run: make build
@@ -28,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Test
       run: make test
@@ -68,7 +71,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Run coverage
       run: make coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+env:
+  GO_VERSION: 1.19
+
 on:
   push:
     tags:
@@ -17,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Set RELEASE_VERSION env
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV


### PR DESCRIPTION
Use environment variable `GO_VERSION` to avoid duplication of Golang versioning config.