### PR TITLE
feat: regulate and split CTRL+C/CTRL+D behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Core feature of this program is the ability to change working directory while st
 This **can not** be done by the program itself, because of `POSIX` security limitations. Without instrumenting
 the shell with aliases `travelgrunt` will not work!
 
+### `CTRL+C` / `CTRL+D` behaviour
+When key combinations `CTRL+C` or `CTRL+D` get pressed during the execution, following occures:
+* `CTRL+C` - program terminates with exit code `1`, under the starting directory path;
+* `CTRL+D` - program terminates with exit code `0`, under the directory path currently selected;
+
 ## How to install? :neckbeard:
 
 ### Install with `homebrew`:

--- a/cmd/travelgrunt/main.go
+++ b/cmd/travelgrunt/main.go
@@ -57,6 +57,10 @@ func buildMenuFromTree(t tree.Tree) string {
 
 		if err != nil {
 			if err.Error() == "^C" {
+				os.Exit(1)
+			}
+
+			if err.Error() == "^D" {
 				return parentID
 			}
 


### PR DESCRIPTION
Set new `CTRL+C` / `CTRL+D` behaviour:
* `CTRL+C` - program terminates with exit code `1`, under the starting directory path;
* `CTRL+D` - program terminates with exit code `0`, under the directory path currently selected;
