### PR TITLE
feat: search by the arbitrary regex instead of rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_NAME    := travelgrunt
-API_VERSION := 0.4
+API_VERSION := 0.5
 BUILD_PATH  := ./cmd/${APP_NAME}
 
 CURRENT_PATCH = $(shell (git fetch --tags && git tag --sort=creatordate | grep -F "v${API_VERSION}." || echo -1) | tail -n1 | sed -r "s/^v([0-9]+\.){2}//")

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ rules:
 
 :bulb: Even while developing `travelgrunt` itself we use it to navigate [package directories](https://github.com/ivanilves/travelgrunt/blob/main/.travelgrunt.yml) of the application :tophat:
 
+## Override configured rules with arbitrary expression
+
+You can search by the arbitrary expression instead of configured rules:
+
+```
+tg -x <EXPRESSION> [<match> <match2> ... <matchN>]
+```
+
 ## Shell aliases and functions
 
 It is **absolutely required** to use `zsh` aliases or `bash` functions. Start from something like this:
@@ -52,8 +60,8 @@ alias tt='_tt(){ travelgrunt -top -out-file ~/.tg-path && cd "$(cat ~/.tg-path)"
 ```
 #### BASH
 ```
-function tg() { 
-	travelgrunt -out-file ~/.tg-path ${@} && cd "$(cat ~/.tg-path)" 
+function tg() {
+	travelgrunt -out-file ~/.tg-path ${@} && cd "$(cat ~/.tg-path)"
 }
 
 function tt() {

--- a/cmd/travelgrunt/main.go
+++ b/cmd/travelgrunt/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/ivanilves/travelgrunt/pkg/config"
+	"github.com/ivanilves/travelgrunt/pkg/config/rule"
 	"github.com/ivanilves/travelgrunt/pkg/directory"
 	"github.com/ivanilves/travelgrunt/pkg/directory/tree"
 	"github.com/ivanilves/travelgrunt/pkg/file"
@@ -18,11 +19,13 @@ import (
 var appVersion = "default"
 
 var outFile string
+var expression string
 var top bool
 var version bool
 
 func init() {
 	flag.StringVar(&outFile, "out-file", "", "output selected path into the file specified")
+	flag.StringVar(&expression, "x", "", "use arbitrary expression passed instead of configured rules")
 	flag.BoolVar(&top, "top", false, "get to the repository top level (root) path")
 	flag.BoolVar(&version, "version", false, "print application version and exit")
 }
@@ -111,6 +114,12 @@ func main() {
 
 	if err != nil {
 		log.Fatalf("failed to load travelgrunt config: %s", err.Error())
+	}
+
+	if expression != "" {
+		rules := []rule.Rule{{NameEx: expression}}
+
+		cfg.Rules = rules
 	}
 
 	entries, paths, err := directory.Collect(rootPath, cfg)


### PR DESCRIPTION
## Override configured rules with arbitrary expression

Search by the arbitrary expression instead of configured rules:

```
tg -x <EXPRESSION> [<match> <match2> ... <matchN>]
```