### PR TITLE
feat: add static links support in addition to SCM ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ rules:
 
 :bulb: Even while developing `travelgrunt` itself we use it to navigate [package directories](https://github.com/ivanilves/travelgrunt/blob/main/.travelgrunt.yml) of the application :tophat:
 
+## Links
+Use links feature to be able to travel outside of the repo in a convenient manner.
+
+Add `links` [string list] section to `.travelgrunt.yml` in-repository config file:
+```yaml
+rules:
+  - mode: terragrunt
+links:
+  - /tmp
+  - submodule-path
+  - ~/projects/other-repo
+```
+Invoke links usage by passing `-l` flag to the CLI app:
+```bash
+$ tg -l
+```
+Typical filter rules do apply for the link selection:
+```bash
+$ tg -l other-repo
+```
+
 ## Override configured rules with arbitrary expression
 
 You can search by the arbitrary expression instead of configured rules:

--- a/fixtures/config/travelgrunt.yml.links
+++ b/fixtures/config/travelgrunt.yml.links
@@ -1,0 +1,5 @@
+rules:
+- mode: terragrunt
+links:
+- /tmp
+- build

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,8 +15,11 @@ var configFile = ".travelgrunt.yml"
 type Config struct {
 	Rules []rule.Rule `yaml:"rules"`
 
+	Links []string `yaml:"links"`
+
 	IsDefault bool
 	UseFiles  bool
+	UseLinks  bool
 }
 
 // DefaultConfig returns default travelgrunt repo-level configuration
@@ -25,6 +28,7 @@ func DefaultConfig() Config {
 		Rules:     []rule.Rule{{ModeFn: mode.IsTerragrunt}},
 		IsDefault: true,
 		UseFiles:  false,
+		UseLinks:  false,
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -79,3 +79,27 @@ func TestNewConfigNormalFlow(t *testing.T) {
 		assert.Nil(err)
 	}
 }
+
+func TestNewConfigLinksFlow(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := map[string]bool{
+		"travelgrunt.yml.whatever": false,
+		"travelgrunt.yml.links":    true,
+	}
+
+	for cfgFile, shouldHaveLinks := range testCases {
+		configFile = cfgFile
+
+		cfg, err := NewConfig(fixturePath)
+
+		if shouldHaveLinks {
+			assert.NotEmpty(cfg.Links)
+		} else {
+			assert.Empty(cfg.Links)
+
+		}
+
+		assert.Nil(err)
+	}
+}

--- a/pkg/directory/links/links.go
+++ b/pkg/directory/links/links.go
@@ -1,0 +1,141 @@
+// Package links provides utilities for resolving and validating file paths,
+// particularly for collecting directory paths relative to a root directory.
+// It supports tilde (~) expansion for the current user's home directory and
+// ensures paths are absolute and valid directories.
+package links
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandPath expands a path starting with "~" to the current user's home directory.
+// It supports "~" (home dir) and "~/path" but not "~user/path".
+// Returns the expanded path or an error if the expansion fails.
+func ExpandPath(path string) (string, error) {
+	if !strings.HasPrefix(path, "~") {
+		return path, nil
+	}
+
+	usr, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current user: %w", err)
+	}
+
+	if path == "~" {
+		return usr.HomeDir, nil
+	}
+
+	if len(path) > 1 && (path[1] == '/' || path[1] == filepath.Separator) {
+		return filepath.Join(usr.HomeDir, path[2:]), nil
+	}
+
+	return "", fmt.Errorf("user home directory expansion (~user) is not supported")
+}
+
+// GetAbsPath converts a path to an absolute path, resolving relative to rootPath.
+// It expands tilde, ensures the result is absolute, and cleans the path.
+// Returns an error for empty paths or invalid expansions.
+func GetAbsPath(path, rootPath string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path cannot be empty")
+	}
+
+	// Expand tilde first
+	expandedPath, err := ExpandPath(path)
+	if err != nil {
+		return "", err
+	}
+
+	// If already absolute, clean and return (no traversal check needed)
+	if filepath.IsAbs(expandedPath) {
+		return filepath.Clean(expandedPath), nil
+	}
+
+	// For relative paths: ensure rootPath is absolute
+	absRoot, err := filepath.Abs(rootPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute root path: %w", err)
+	}
+
+	// Join and clean
+	absPath := filepath.Join(absRoot, expandedPath)
+	absPath = filepath.Clean(absPath)
+
+	// Prevent path traversal outside root (only for relative paths)
+	if !strings.HasPrefix(absPath, absRoot+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q resolves outside root %q", path, absRoot)
+	}
+
+	return absPath, nil
+}
+
+// ValidatePath checks if a path exists and is a directory.
+// Returns specific errors for non-existence, permission issues, or non-directory paths.
+func ValidatePath(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("path %q does not exist", path)
+		}
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied for path %q", path)
+		}
+		return fmt.Errorf("cannot access path %q: %w", path, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("path %q is not a directory", path)
+	}
+
+	return nil
+}
+
+// Collect processes a list of link paths, resolving and validating them as directories.
+// It returns a map of original to absolute paths, a slice of valid original paths,
+// and an error if validation fails or no valid paths remain.
+// All paths are resolved relative to rootPath, which is made absolute.
+func Collect(rootPath string, linkPaths []string) (map[string]string, []string, error) {
+	if len(linkPaths) == 0 {
+		return nil, nil, fmt.Errorf("no links defined in config")
+	}
+
+	linkToAbsPath := make(map[string]string, len(linkPaths))
+	validLinks := make([]string, 0, len(linkPaths))
+	var validationErrors []string
+
+	for _, link := range linkPaths {
+		if link == "" {
+			continue // Skip empty links
+		}
+
+		// Resolve to absolute path
+		absPath, err := GetAbsPath(link, rootPath)
+		if err != nil {
+			validationErrors = append(validationErrors, fmt.Sprintf("link %q: %v", link, err))
+			continue
+		}
+
+		// Validate path
+		if err := ValidatePath(absPath); err != nil {
+			validationErrors = append(validationErrors, fmt.Sprintf("link %q (resolved to %q): %v", link, absPath, err))
+			continue
+		}
+
+		linkToAbsPath[link] = absPath
+		validLinks = append(validLinks, link)
+	}
+
+	if len(validationErrors) > 0 {
+		return nil, nil, fmt.Errorf("link validation failed:\n  - %s", strings.Join(validationErrors, "\n  - "))
+	}
+
+	if len(validLinks) == 0 {
+		return nil, nil, fmt.Errorf("no valid links found in config")
+	}
+
+	return linkToAbsPath, validLinks, nil
+}

--- a/pkg/directory/links/links_test.go
+++ b/pkg/directory/links/links_test.go
@@ -1,0 +1,174 @@
+package links
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	invalidPath = "/c2RmZ3JlZ2ZncnR3Z3I0aGd3dGd3d3d3d3d3d2RmZGZmZnJlZmdydDRndnQ0M3RodWprbDhpb2s4"
+)
+
+func TestExpandPath(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := map[string]bool{
+		"/tmp":           true,  // absolute, no expansion
+		"relative/path":  true,  // relative, no expansion
+		"~":              true,  // home directory
+		"~/projects":     true,  // home with path
+		"~user/projects": false, // ~username not supported
+	}
+
+	for path, expectedSuccess := range testCases {
+		result, err := ExpandPath(path)
+
+		if expectedSuccess {
+			assert.NotEmpty(result)
+			assert.Nil(err)
+		} else {
+			assert.Empty(result)
+			assert.NotNil(err)
+		}
+	}
+}
+
+func TestGetAbsPath(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpDir := t.TempDir()
+
+	testCases := map[string]struct {
+		path            string
+		rootPath        string
+		expectedSuccess bool
+	}{
+		"absolute path": {
+			path:            "/tmp",
+			rootPath:        tmpDir,
+			expectedSuccess: true,
+		},
+		"relative path": {
+			path:            "build",
+			rootPath:        tmpDir,
+			expectedSuccess: true,
+		},
+		"empty path": {
+			path:            "",
+			rootPath:        tmpDir,
+			expectedSuccess: false,
+		},
+		"tilde path": {
+			path:            "~/projects",
+			rootPath:        tmpDir,
+			expectedSuccess: true,
+		},
+		"parent traversal": {
+			path:            "../../etc",
+			rootPath:        tmpDir,
+			expectedSuccess: false, // Should be blocked
+		},
+	}
+
+	for name, tc := range testCases {
+		result, err := GetAbsPath(tc.path, tc.rootPath)
+
+		if tc.expectedSuccess {
+			assert.NotEmpty(result, "test case: %s", name)
+			assert.Nil(err, "test case: %s", name)
+			assert.True(filepath.IsAbs(result), "test case: %s should return absolute path", name)
+		} else {
+			assert.Empty(result, "test case: %s", name)
+			assert.NotNil(err, "test case: %s", name)
+		}
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "testfile.txt")
+
+	err := os.WriteFile(tmpFile, []byte("test"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := map[string]bool{
+		tmpDir:      true,  // valid directory
+		tmpFile:     false, // file, not directory
+		invalidPath: false, // non-existent
+	}
+
+	for path, expectedSuccess := range testCases {
+		err := ValidatePath(path)
+
+		if expectedSuccess {
+			assert.Nil(err)
+		} else {
+			assert.NotNil(err)
+		}
+	}
+}
+
+func TestCollect(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "subdir")
+
+	err := os.Mkdir(subDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := map[string]struct {
+		rootPath        string
+		linkPaths       []string
+		expectedSuccess bool
+	}{
+		"valid absolute and relative": {
+			rootPath:        tmpDir,
+			linkPaths:       []string{tmpDir, "subdir"},
+			expectedSuccess: true,
+		},
+		"empty links": {
+			rootPath:        tmpDir,
+			linkPaths:       []string{},
+			expectedSuccess: false,
+		},
+		"invalid path": {
+			rootPath:        tmpDir,
+			linkPaths:       []string{invalidPath},
+			expectedSuccess: false,
+		},
+		"mixed valid and empty": {
+			rootPath:        tmpDir,
+			linkPaths:       []string{tmpDir, "", "subdir"},
+			expectedSuccess: true,
+		},
+		"only empty strings": {
+			rootPath:        tmpDir,
+			linkPaths:       []string{"", ""},
+			expectedSuccess: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		entries, paths, err := Collect(tc.rootPath, tc.linkPaths)
+
+		if tc.expectedSuccess {
+			assert.Greater(len(entries), 0, "test case: %s", name)
+			assert.Greater(len(paths), 0, "test case: %s", name)
+			assert.Nil(err, "test case: %s", name)
+		} else {
+			assert.Equal(0, len(entries), "test case: %s", name)
+			assert.Equal(0, len(paths), "test case: %s", name)
+			assert.NotNil(err, "test case: %s", name)
+		}
+	}
+}

--- a/pkg/directory/tree/tree.go
+++ b/pkg/directory/tree/tree.go
@@ -123,7 +123,10 @@ func (t Tree) LevelCount() int {
 
 func (t Tree) levelItems(idx int) (items map[string]string) {
 	if len(t.levels) <= idx+1 {
-		return nil
+		// continue on shallow trees with one level only
+		if len(t.levels) > 1 {
+			return nil
+		}
 	}
 
 	items = make(map[string]string, len(t.levels[idx]))


### PR DESCRIPTION
# WHA?
Add static links support in addition to SCM ones.

# WHY?
To be able to travel outside of the repo in a convenient manner.

# USAGE?

Add links to your in-repo `.travelgrunt.yml`:
```yaml
rules:
- mode: terragrunt
links:
- /tmp
- /var/log
- ~/projects/other-repo
```
Use links by passing `-l` flag to the app:
```
$ tg -l
``` 
Typical filter rules do apply for the link selection:
```
$ tg -l log
``` 
